### PR TITLE
Add basic simulation modules and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/examples/basic_simulation.py
+++ b/examples/basic_simulation.py
@@ -1,0 +1,16 @@
+"""Run a basic φ⁰ simulation."""
+import numpy as np
+from src.features import extract_psi0_features
+from src.phi0 import phi0_score
+
+
+def main() -> None:
+    rng = np.random.default_rng(42)
+    image = rng.random((32, 32))
+    features = extract_psi0_features(image)
+    score = phi0_score(features)
+    print(f"φ⁰ score: {score:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,4 @@
+from .features import extract_psi0_features
+from .phi0 import phi0_score
+
+__all__ = ["extract_psi0_features", "phi0_score"]

--- a/src/features.py
+++ b/src/features.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+
+def extract_psi0_features(image: np.ndarray) -> np.ndarray:
+    """Generate a simple 8-channel feature tensor.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        2D input array representing an image.
+
+    Returns
+    -------
+    np.ndarray
+        Feature tensor of shape ``(H, W, 8)``.
+    """
+    if image.ndim != 2:
+        raise ValueError("image must be 2D")
+
+    h, w = image.shape
+    features = np.zeros((h, w, 8), dtype=np.float32)
+
+    gx, gy = np.gradient(image)
+
+    features[..., 0] = image
+    features[..., 1] = image ** 2
+    features[..., 2] = gx
+    features[..., 3] = gy
+    features[..., 4] = np.sqrt(gx ** 2 + gy ** 2)
+    features[..., 5] = gx * gy
+    features[..., 6] = (image - image.mean()) / (image.std() + 1e-6)
+    features[..., 7] = (image > image.mean()).astype(np.float32)
+
+    return features

--- a/src/phi0.py
+++ b/src/phi0.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+
+def phi0_score(features: np.ndarray) -> float:
+    """Compute a simple φ⁰ score from the feature tensor.
+
+    Parameters
+    ----------
+    features : np.ndarray
+        Tensor of shape ``(H, W, C)``.
+
+    Returns
+    -------
+    float
+        Scalar score summarizing the features.
+    """
+    if features.ndim != 3:
+        raise ValueError("features must be a 3D tensor")
+
+    c = features.shape[-1]
+    weights = np.arange(1, c + 1, dtype=np.float32)
+    mean_features = features.reshape(-1, c).mean(axis=0)
+    score = float(np.dot(mean_features, weights) / weights.sum())
+    return score

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,8 @@
+import numpy as np
+from src.features import extract_psi0_features
+
+
+def test_extract_psi0_features_shape():
+    img = np.zeros((10, 20))
+    feats = extract_psi0_features(img)
+    assert feats.shape == (10, 20, 8)

--- a/tests/test_phi0.py
+++ b/tests/test_phi0.py
@@ -1,0 +1,11 @@
+import numpy as np
+from src.features import extract_psi0_features
+from src.phi0 import phi0_score
+
+
+def test_phi0_score_scalar():
+    rng = np.random.default_rng(0)
+    img = rng.random((5, 5))
+    features = extract_psi0_features(img)
+    score = phi0_score(features)
+    assert isinstance(score, float)


### PR DESCRIPTION
## Summary
- add simple feature extraction and φ⁰ scoring modules
- create unit tests for the new modules
- provide an example script showing a basic φ⁰ simulation
- ignore Python cache files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68525d01850883248321480c574f21d8