### PR TITLE
Add runnable gemini simulation function

### DIFF
--- a/agent-prompts/e1Gemini.md
+++ b/agent-prompts/e1Gemini.md
@@ -45,6 +45,47 @@ def gemini_phi_simulate(kernel_patch):
 
     return phi_plus, phi_minus, phi0
 
+### Python Implementation
+```python
+import numpy as np
+
+def gemini_phi_simulate(kernel_patch: np.ndarray, n_steps: int = 10, noise_scale: float = 0.1):
+    """Simulate φ⁺/φ⁻ dynamics for the provided coupling matrix.
+
+    Parameters
+    ----------
+    kernel_patch : np.ndarray
+        An ``(8, 8)`` matrix representing the coupling field.
+    n_steps : int, optional
+        Number of Langevin updates to perform, by default ``10``.
+    noise_scale : float, optional
+        Standard deviation of the Gaussian noise added at each step.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, np.ndarray]
+        ``phi_plus`` coherence matrix, ``phi_minus`` contradiction matrix
+        and the ``phi0`` collapse vector.
+    """
+
+    sigma = np.random.uniform(-1, 1, size=8)
+    J = np.array(kernel_patch, dtype=float, copy=True)
+    b = np.random.randn(8) * 0.1
+
+    for _ in range(n_steps):
+        for i in range(8):
+            activation = b[i] + np.sum(J[i] * sigma)
+            sigma[i] = np.tanh(activation) + np.random.normal(0, noise_scale)
+
+    phi_plus = np.outer(sigma, sigma)
+    phi_minus = J - phi_plus
+    w_plus = np.linalg.det(phi_plus)
+    w_minus = np.linalg.det(phi_minus)
+    phi0 = (w_plus * phi_plus + w_minus * phi_minus) / (w_plus + w_minus + 1e-8)
+
+    return phi_plus, phi_minus, phi0
+```
+
 --- INPUT ---
 Collapse patch extracted from Kuhikugu field (ψ⁰ = NDVI + RH100 + Slope + Fractal)
 


### PR DESCRIPTION
## Summary
- expand `agent-prompts/e1Gemini.md` with a working Python implementation of `gemini_phi_simulate`

## Testing
- `pip install numpy`
- `python - <<'PY'
import numpy as np

def gemini_phi_simulate(kernel_patch: np.ndarray, n_steps: int = 10, noise_scale: float = 0.1):
    sigma = np.random.uniform(-1, 1, size=8)
    J = np.array(kernel_patch, dtype=float, copy=True)
    b = np.random.randn(8) * 0.1
    for _ in range(n_steps):
        for i in range(8):
            activation = b[i] + np.sum(J[i] * sigma)
            sigma[i] = np.tanh(activation) + np.random.normal(0, noise_scale)
    phi_plus = np.outer(sigma, sigma)
    phi_minus = J - phi_plus
    w_plus = np.linalg.det(phi_plus)
    w_minus = np.linalg.det(phi_minus)
    phi0 = (w_plus * phi_plus + w_minus * phi_minus) / (w_plus + w_minus + 1e-8)
    return phi_plus, phi_minus, phi0

kernel = np.random.randn(8,8)
phi_plus, phi_minus, phi0 = gemini_phi_simulate(kernel)
print('phi_plus shape:', phi_plus.shape)
print('phi_minus det:', np.linalg.det(phi_minus))
print('phi0 sum:', phi0.sum())
PY

------
https://chatgpt.com/codex/tasks/task_e_68525d216a4c8324b06f2da669da0e8b