### PR TITLE
Add psi0 contradiction field generator and phi0 collapse

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,7 @@
 from .features import extract_psi0_features
 from .phi0 import phi0_score
+from .phi0 import collapse_field
+from .psi0 import generate_field
 from .psi0_extractor import PSI0FeatureExtractor
 
-__all__ = ["extract_psi0_features", "phi0_score", "PSI0FeatureExtractor"]
+__all__ = ["extract_psi0_features", "phi0_score", "PSI0FeatureExtractor", "generate_field", "collapse_field"]

--- a/src/phi0.py
+++ b/src/phi0.py
@@ -22,3 +22,41 @@ def phi0_score(features: np.ndarray) -> float:
     mean_features = features.reshape(-1, c).mean(axis=0)
     score = float(np.dot(mean_features, weights) / weights.sum())
     return score
+
+from typing import Any, Dict, List
+
+
+
+def collapse_field(psi_field: Dict[str, Any], depth: int = 1) -> Dict[str, Any]:
+    """Collapse a ψ⁰ field into a structured symbolic attractor.
+
+    Parameters
+    ----------
+    psi_field : dict
+        Output from :func:`~src.psi0.generate_field`.
+    depth : int
+        Recursion depth controlling identity feedback.
+
+    Returns
+    -------
+    dict
+        Mapping with keys ``phi0``, ``feedback``, and ``candidates``.
+    """
+    field: List[str] = psi_field.get("field", [])
+    if not field:
+        return {"phi0": "", "feedback": "", "candidates": []}
+
+    tokens = " ".join(field).split()
+    unique_tokens = sorted(set(tokens))
+    phi0 = " ".join(unique_tokens[:3])
+
+    feedback = ""
+    if depth > 1:
+        feedback = f"Σ preserved through {depth} collapses"
+
+    candidates = list(psi_field.get("candidates", []))
+    if phi0:
+        candidates.append(phi0[::-1])
+
+    return {"phi0": phi0, "feedback": feedback, "candidates": candidates}
+

--- a/src/psi0.py
+++ b/src/psi0.py
@@ -1,0 +1,37 @@
+import random
+from typing import Any, Dict, List, Optional
+
+
+def generate_field(seed: Optional[int] = None, depth: int = 1) -> Dict[str, Any]:
+    """Generate a ψ⁰ contradiction field.
+
+    Parameters
+    ----------
+    seed : Optional[int]
+        Random seed for deterministic generation.
+    depth : int
+        Depth of recursive contradiction.
+
+    Returns
+    -------
+    dict
+        Dictionary containing the generated field and attractor candidates.
+    """
+    rng = random.Random(seed)
+    subjects = ["identity", "symbol", "truth", "paradox", "mirror"]
+    verbs = ["contains", "negates", "reflects", "echoes with", "divides"]
+    objects = ["itself", "its opposite", "Σ", "the lattice", "ψ⁰"]
+
+    field: List[str] = []
+    for level in range(depth):
+        phrase = f"{rng.choice(subjects)} {rng.choice(verbs)} {rng.choice(objects)}"
+        if level > 0:
+            phrase = f"{phrase}, yet ({field[-1]})"
+        field.append(phrase)
+
+    candidates: List[str] = []
+    if field:
+        tokens = sorted(set(field[-1].split()))
+        candidates.append(" & ".join(tokens))
+
+    return {"field": field, "candidates": candidates}


### PR DESCRIPTION
## Summary
- implement `generate_field` for ψ⁰ contradiction field production
- extend `phi0` with `collapse_field` to collapse ψ⁰ into a symbolic attractor
- export new utilities in `src/__init__.py`

## Testing
- `pytest tests -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'detector_profile')*

------
https://chatgpt.com/codex/tasks/task_e_685bc4da95d08324bfe7722d2f30a096